### PR TITLE
Added messageFormatVersion 

### DIFF
--- a/src/main/java/ch/hevs/cloudio/endpoint/GenericJacksonMessageFormat.java
+++ b/src/main/java/ch/hevs/cloudio/endpoint/GenericJacksonMessageFormat.java
@@ -44,6 +44,7 @@ class GenericJacksonMessageFormat implements CloudioMessageFormat {
             generator.writeStartObject();
 
             generator.writeStringField("version", endpoint.getVersion());
+            generator.writeNumberField("messageFormatVersion", 2);
             generator.writeArrayFieldStart("supportedFormats");
             for (String format : endpoint.getSupportedFormats()) {
                 generator.writeString(format);


### PR DESCRIPTION
Added messageFormatVersion field that is independent of the actual endoint version.

This fixes some conceptual issues:
- message formats should never have minor versions, an incrementing number is much more useful.
- Decouples the message format version from the endpoint library version.